### PR TITLE
Remove wallpaper-engine-types dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,8 +30,7 @@
         "ts-jest": "^29.4.6",
         "ts-node": "^10.9.2",
         "typescript": "^5.9.3",
-        "vite": "^6.4.1",
-        "wallpaper-engine-types": "^1.0.12"
+        "vite": "^6.4.1"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -11073,12 +11072,6 @@
       "dependencies": {
         "makeerror": "1.0.12"
       }
-    },
-    "node_modules/wallpaper-engine-types": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/wallpaper-engine-types/-/wallpaper-engine-types-1.0.12.tgz",
-      "integrity": "sha512-alKJmLOCibPo1c/sJBS5sBuaUU2kJfir+v1bMXyQcjVXumbNJDP6PGuGNTiTXh9DeHzJAuUM82ZmDiWoFPI7EQ==",
-      "dev": true
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -37,8 +37,7 @@
     "ts-jest": "^29.4.6",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.3",
-    "vite": "^6.4.1",
-    "wallpaper-engine-types": "^1.0.12"
+    "vite": "^6.4.1"
   },
   "dependencies": {
     "dateformat": "^5.0.3",

--- a/src/app/base/wpe.ts
+++ b/src/app/base/wpe.ts
@@ -2,7 +2,7 @@ import {
   WallpaperMediaPlaybackEvent,
   WallpaperMediaPropertiesEvent,
   WallpaperMediaTimelineEvent,
-} from 'wallpaper-engine-types';
+} from '../../types/wallpaper-engine';
 
 export interface WpeEventReceiver {
   readonly supportsWpeEvents: true;

--- a/src/app/screens/wpe-player-2.ts
+++ b/src/app/screens/wpe-player-2.ts
@@ -3,7 +3,7 @@ import {
   WallpaperMediaPlaybackState,
   WallpaperMediaPropertiesEvent,
   WallpaperMediaTimelineEvent,
-} from 'wallpaper-engine-types';
+} from '../../types/wallpaper-engine';
 import { TextScrollerScreen } from '.';
 import { center, formatTime, left, repeat } from '../../utils';
 import {

--- a/src/app/screens/wpe-player.ts
+++ b/src/app/screens/wpe-player.ts
@@ -2,7 +2,7 @@ import {
   WallpaperMediaPlaybackEvent,
   WallpaperMediaPropertiesEvent,
   WallpaperMediaTimelineEvent,
-} from 'wallpaper-engine-types';
+} from '../../types/wallpaper-engine';
 import { Logger } from '../../log';
 import {
   center,

--- a/src/types/wallpaper-engine.d.ts
+++ b/src/types/wallpaper-engine.d.ts
@@ -1,0 +1,42 @@
+export type WallpaperMediaPlaybackState = number;
+
+export interface WallpaperMediaPlaybackEvent {
+  state: WallpaperMediaPlaybackState;
+}
+
+export interface WallpaperMediaTimelineEvent {
+  position: number;
+  duration: number;
+}
+
+export interface WallpaperMediaPropertiesEvent {
+  title?: string;
+  artist?: string;
+  albumTitle?: string;
+  subTitle?: string;
+  contentType?: string;
+}
+
+export interface WallpaperPropertyListener {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  applyUserProperties?: (properties: { [key: string]: { value?: any } }) => void;
+}
+
+declare global {
+  interface Window {
+    wallpaperPropertyListener: WallpaperPropertyListener;
+    wallpaperRegisterMediaPlaybackListener(
+      callback: (event: WallpaperMediaPlaybackEvent) => void,
+    ): void;
+    wallpaperRegisterMediaTimelineListener(
+      callback: (event: WallpaperMediaTimelineEvent) => void,
+    ): void;
+    wallpaperRegisterMediaPropertiesListener(
+      callback: (event: WallpaperMediaPropertiesEvent) => void,
+    ): void;
+    wallpaperRegisterMediaThumbnailListener(
+      callback: (thumbnail: string) => void,
+    ): void;
+    wallpaperRegisterAudioListener(callback: (audioLevels: number[]) => void): void;
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,7 @@
     "noFallthroughCasesInSwitch": true,
 
     /* Type Checking */
-    "types": ["wallpaper-engine-types", "jest"]
+    "types": ["jest"]
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary

- `wallpaper-engine-types` was unpublished on 2026-02-04 and no longer installable
- Extracted all used types into `src/types/wallpaper-engine.d.ts`: 4 event interfaces + `Window` augmentation for all `wallpaperRegister*` listeners and `wallpaperPropertyListener`
- Updated imports in 3 source files to point to local path
- Removed package from `package.json` and `tsconfig.json` types array

## Test plan

- [x] `tsc --noEmit` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)